### PR TITLE
Generates alias when none is given

### DIFF
--- a/endpoints/shorten_endpoint.py
+++ b/endpoints/shorten_endpoint.py
@@ -2,13 +2,17 @@ import validators
 from fastapi import APIRouter, HTTPException
 from functions.fetch_url_details import fetch_url_details
 from functions.get_db import get_db
+from functions.generate_alias import generate_alias
 
 TLD = "https://url.beckham.io"
 router = APIRouter()
 
 
 @router.put("/shorten")
-def shorten_url(alias: str, url: str):
+def shorten_url(url: str, alias: str = None):
+    if alias is None:
+        alias = generate_alias()
+
     if fetch_url_details(alias) is not None:
         raise HTTPException(status_code=409, detail="Alias already exists")
 

--- a/endpoints/shorten_endpoint.py
+++ b/endpoints/shorten_endpoint.py
@@ -10,11 +10,16 @@ router = APIRouter()
 
 @router.put("/shorten")
 def shorten_url(url: str, alias: str = None):
-    if alias is None:
-        alias = generate_alias()
-
-    if fetch_url_details(alias) is not None:
+    if fetch_url_details(alias) is not None and alias is not None:
         raise HTTPException(status_code=409, detail="Alias already exists")
+
+    # NOTE: We loop here to make sure the random alias isn't already taken
+    #       In most instances, this loop will only run once.
+    if alias is None:
+        while True:
+            alias = generate_alias()
+            if fetch_url_details(alias) is None:
+                break
 
     if not validators.url(url):
         raise HTTPException(status_code=400, detail="Invalid URL")

--- a/functions/generate_alias.py
+++ b/functions/generate_alias.py
@@ -1,0 +1,10 @@
+import random
+import string
+
+
+def generate_alias():
+    length = 8
+    random_string = "".join(
+        random.choices(string.ascii_letters + string.digits, k=length)
+    )
+    return random_string

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -122,6 +122,14 @@ class TestE2E:
         assert response.json()["url"] == URL
         assert response.json()["visits"] == 5
 
+    def test_shorten_no_alias(self):
+        response = client.put("/api/shorten", params={"url": URL}, headers=auth_headers)
+        alias = response.json()["alias"]
+        assert response.status_code == 200
+        assert len(response.json()["alias"]) == 8
+        assert response.json()["url"] == URL
+        assert response.json()["short_url"] == f"https://url.beckham.io/{alias}"
+
     def test_shorten_override(self):
         response = client.put(
             "/api/shorten", params={"alias": ALIAS, "url": URL}, headers=auth_headers


### PR DESCRIPTION
This allows you to shorten a url without specifying an alias. It generates a random 8 character sting, then checks that string for collisions in the database.